### PR TITLE
python-gobject and gtk4 added to package list

### DIFF
--- a/install/arch/install_packages.sh
+++ b/install/arch/install_packages.sh
@@ -25,6 +25,7 @@ installer_packages=(
     "gtk4"
     "libadwaita"
     "jq"
+    "python-gobject"
 )
 
 installer_yay=(

--- a/install/fedora/install_packages.sh
+++ b/install/fedora/install_packages.sh
@@ -19,6 +19,8 @@ installer_packages=(
     "mozilla-fira-sans-fonts"
     "fira-code-fonts"
     "wlogout"
+    "python3-gobject" 
+    "gtk4"
 )
 
 # PLEASE NOTE: Add more packages at the end of the following command


### PR DESCRIPTION
Packages are required to execute the ML4W Hyprland Settings app on minimal installations. 