### PR TITLE
Volume & media binds with keyboard

### DIFF
--- a/dotfiles/.config/hypr/conf/binds.conf
+++ b/dotfiles/.config/hypr/conf/binds.conf
@@ -54,3 +54,13 @@ bind = $mainMod, mouse_up, workspace, e-1 # Scroll workspaces
 # Move/resize windows with mainMod + LMB/RMB and dragging
 bindm = $mainMod, mouse:272, movewindow # Move window
 bindm = $mainMod, mouse:273, resizewindow # Resize window
+
+# Increase/decrease/mute volume with keyboard volume keys 
+bindel = , XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
+bindel = , XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+bindl = , XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+
+# Play/pause, skip to previous/next track with keyboard media keys 
+bindl = , XF86AudioPlay, exec, playerctl play-pause
+bindl = , XF86AudioPrev, exec, playerctl previous
+bindl = , XF86AudioNext, exec, playerctl next


### PR DESCRIPTION
This should allow media controls using keyboard keys such as special media keys, volume knobs, and keyboard shortcuts.

Some of the key bindings depend on `playerctl`, which is included as a dependency through `waybar`, so there's no need for an additional installation step.

**Testing Notes:**
- No known issues on Fedora.
- Please ensure it functions correctly on Arch systems before merging, as I haven't tested it on that distribution.