### PR TITLE
Hyprland 0.45.0 breaking changes in decoration.conf

### DIFF
--- a/dotfiles/.config/hypr/conf/decoration.conf
+++ b/dotfiles/.config/hypr/conf/decoration.conf
@@ -6,8 +6,10 @@ decoration {
         size = 3
         passes = 1
     }
-    drop_shadow = true
-    shadow_range = 4
-    shadow_render_power = 3
-    col.shadow = rgba(1a1a1aee)
+    shadow {
+        enabled = true
+        range = 4
+        render_power = 3
+        color = rgba(1a1a1aee)
+    }
 }


### PR DESCRIPTION
In Hyprland 0.45.0 the shadow options have moved from individual functions to a subcategory.