### PR TITLE
Added packages and key bindings for brightness and volume

### DIFF
--- a/dotfiles/.config/hypr/conf/binds.conf
+++ b/dotfiles/.config/hypr/conf/binds.conf
@@ -50,6 +50,8 @@ bind = , XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK
 bind = , XF86AudioLowerVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK@ 5%-
 bind = , XF86MonBrightnessUp, exec, brightnessctl set 10%+
 bind = , XF86MonBrightnessDown, exec, brightnessctl set 10%-
+bind = , XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+
 
 # Scroll through existing workspaces with mainMod + scroll
 bind = $mainMod, mouse_down, workspace, e+1 # Scroll workspaces 

--- a/dotfiles/.config/hypr/conf/binds.conf
+++ b/dotfiles/.config/hypr/conf/binds.conf
@@ -46,6 +46,10 @@ bind = $mainMod SHIFT, 7, movetoworkspace, 7 #  Move window to workspace 7
 bind = $mainMod SHIFT, 8, movetoworkspace, 8 #  Move window to workspace 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9 #  Move window to workspace 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10 #  Move window to workspace 10
+bind = , XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK@ 5%+
+bind = , XF86AudioLowerVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK@ 5%-
+bind = , XF86MonBrightnessUp, exec, brightnessctl set 10%+
+bind = , XF86MonBrightnessDown, exec, brightnessctl set 10%-
 
 # Scroll through existing workspaces with mainMod + scroll
 bind = $mainMod, mouse_down, workspace, e+1 # Scroll workspaces 

--- a/install/arch/install_packages.sh
+++ b/install/arch/install_packages.sh
@@ -26,6 +26,8 @@ installer_packages=(
     "libadwaita"
     "jq"
     "python-gobject"
+    "wireplumber"
+    "brightnessctl"
 )
 
 installer_yay=(


### PR DESCRIPTION
Changes made:
- Added required packages:
  - wireplumber for volume control
  - brightnessctl for screen brightness control

- Added keybindings for:
  - Volume control (increase/decrease) using wpctl
  - Screen brightness control using brightnessctl

These changes enable basic system controls for Hyprland users to adjust screen brightness and audio volume using function keys.