### PR TITLE
Added packages & key bindings for volume, brightness, airplane mode, and refresh

### DIFF
--- a/dotfiles/.config/hypr/conf/binds.conf
+++ b/dotfiles/.config/hypr/conf/binds.conf
@@ -2,7 +2,7 @@
 
 # SUPER key
 $mainMod = SUPER
-
+	
 # Actions
 bind = $mainMod, RETURN, exec, alacritty # Open Alactritty
 bind = $mainMod, Q, killactive # Close current window
@@ -16,6 +16,14 @@ bind = $mainMod, J, togglesplit, # dwindle
 bind = $mainMod, B, exec, ~/.config/ml4w/settings/browser.sh # Opens the browser
 bind = $mainMod SHIFT, B, exec, ~/.config/ml4w/scripts/reload-waybar.sh # Reload Waybar
 bind = $mainMod SHIFT, W, exec, ~/.config/ml4w/scripts/reload-hyprpaper.sh # Reload hyprpaper after a changing the wallpaper
+bind = , XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK@ 5%+
+bind = , XF86AudioLowerVolume, exec, wpctl set-volume -l 1.4 @DEFAULT_AUDIO_SINK@ 5%-
+bind = , XF86MonBrightnessUp, exec, brightnessctl set 10%+
+bind = , XF86MonBrightnessDown, exec, brightnessctl set 10%-
+bind = , XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+bind = , XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle
+bind = , XF86WLAN, exec, nmcli radio wifi toggle
+bind = , XF86Refresh, exec, xdotool key F5
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l # Move focus left

--- a/install/arch/install_packages.sh
+++ b/install/arch/install_packages.sh
@@ -26,6 +26,10 @@ installer_packages=(
     "libadwaita"
     "jq"
     "python-gobject"
+    "xdotool"
+    "brightnessctl"
+    "networkmanager"
+    "wireplumber"
 )
 
 installer_yay=(


### PR DESCRIPTION
Description: This PR introduces keybindings for various system functions, now mapped to their respective keys on manufactured keyboards, providing a seamless experience. The following actions are now directly accessible via dedicated keys:

    Volume control: Adjust system volume with the keyboard's volume keys.
    Brightness control: Change screen brightness using the keyboard's brightness keys.
    Airplane mode toggle: Enable or disable airplane mode with the keyboard's airplane mode key.
    Refresh: Perform a quick system refresh using the refresh key.

Additionally, the necessary packages have been added to ensure full compatibility with these keybindings:

    xdotool: Utilized for simulating keyboard and mouse input in scripts.
    brightnessctl: Handles screen brightness adjustments.
    networkmanager: Manages network connections, including airplane mode functionality.
    wireplumber: Manages PipeWire audio and device sessions.