### PR TITLE
Fix Clock Partial Visibility on 1920x1080 Screens

### DIFF
--- a/dotfiles/.config/hypr/hyprlock.conf
+++ b/dotfiles/.config/hypr/hyprlock.conf
@@ -49,7 +49,7 @@ label {
     color = rgba(200, 200, 200, 1.0)
     font_size = 55
     font_family = Fira Semibold
-    position = -100, -40
+    position = -100, 40
     halign = right
     valign = bottom
     shadow_passes = 5


### PR DESCRIPTION
# Fix Clock Partial Visibility on 1920x1080 Screens  

## Description  
On a **1920x1080** display, the clock in `hyprlock` is **partially cut off** due to the **y-coordinate being set to `-40`**.  
This PR updates the position to **ensure full visibility** by adjusting the y-coordinate to `40`.  

## Changes  
### Before (Partially Visible Clock):  
```ini
position = -100, -40
```

### After (Fully Visible Clock):  
```ini
position = -100, 40
```

### Why This Fix?    
- This adjustment ensures the clock is **fully visible** without modifying other UI elements.  

### Testing  
- Applied the change on a **1920x1080** display.  
- Verified that the clock is now **fully visible and properly aligned**.  