### PR TITLE
Fix decoration.conf errors on hyprland 0.47

### DIFF
--- a/dotfiles/.config/hypr/conf/decoration.conf
+++ b/dotfiles/.config/hypr/conf/decoration.conf
@@ -6,8 +6,10 @@ decoration {
         size = 3
         passes = 1
     }
-    drop_shadow = true
-    shadow_range = 4
-    shadow_render_power = 3
-    col.shadow = rgba(1a1a1aee)
+    shadow {
+        enabled = true
+        range = 4
+        render_power = 3
+        color = rgba(1a1a1aee)
+    }
 }


### PR DESCRIPTION
Looks like the data structure for decoration config has changed yet again.

Closes (I think, there's no real information on the ticket) https://github.com/mylinuxforwork/hyprland-starter/issues/47

Fixes a host of errors on hyprland startup:
![image](https://github.com/user-attachments/assets/314ebc2f-203f-426c-962e-8272fcac80f2)
