### PR TITLE
Update style.css to increase specificity of margin override

### DIFF
--- a/dotfiles/.config/waybar/style.css
+++ b/dotfiles/.config/waybar/style.css
@@ -146,11 +146,11 @@ window#waybar.empty #window {
  * Modules
  * ----------------------------------------------------- */
 
-.modules-left > widget:first-child > #workspaces {
+.modules-left > widget:first-child > :not(#dontusethisid) {
     margin-left: 0;
 }
 
-.modules-right > widget:last-child > #workspaces {
+.modules-right > widget:last-child > :not(#dontusethisid) {
     margin-right: 0;
 }
 


### PR DESCRIPTION
Fixes margin of the widgets still applying due to lower specificity of the selector comparyed to, say, `#clock` which applies a margin. Since !important doesn't work, this is the next best thing.